### PR TITLE
chord-3 -> main

### DIFF
--- a/notes/ScorePitchUtils.h
+++ b/notes/ScorePitchUtils.h
@@ -51,14 +51,14 @@ ScorePitchUtils::getNotationNote(const Scale& scale, const MidiNote& midiNote, b
 inline ScorePitchUtils::NotationNote
 ScorePitchUtils::getNotationNoteForce(const Scale& scale, const MidiNote& midiNote, bool bassStaff, bool useSharps) {
     // not correct, but will get tests compiling...
-    return getNotationNote(scale, midiNote, bassStaff);
+    return getNotationNoteEx(scale, midiNote, bassStaff, useSharps ? SharpsFlatsPref::Sharps : SharpsFlatsPref::Flats);
 }
 
 inline ScorePitchUtils::NotationNote
-ScorePitchUtils::getNotationNoteEx(const Scale& scale, const MidiNote& midiNote, bool bassStaff, SharpsFlatsPref _pref) {
-    assert(_pref == SharpsFlatsPref::DontCare);
-    ScaleNote sn = scale.m2s(midiNote);
-    scale._validateScaleNote(sn);
+ScorePitchUtils::getNotationNoteEx(const Scale& scale, const MidiNote& midiNote, bool bassStaff, SharpsFlatsPref pref) {
+//    assert(_pref == SharpsFlatsPref::DontCare);
+    ScaleNote sn = scale.m2s(midiNote, pref);
+    scale._validateScaleNote(sn, pref);
     //SQINFO("--in getNotationNote srn octave=%d degree=%d adj=%d (none, sharp, flat)", sn.getOctave(), sn.getDegree(), int(sn.getAdjustment()));
     //SQINFO("-- midiPitch is %d", midiNote.get());
 
@@ -78,7 +78,9 @@ ScorePitchUtils::getNotationNoteEx(const Scale& scale, const MidiNote& midiNote,
         //SQINFO("getting acciendtal from adj, accid = %d", int(accidental));
     }
 
-    const auto pref = scale.getSharpsFlatsPref();
+    if (pref == SharpsFlatsPref::DontCare) {
+        pref = scale.getSharpsFlatsPref();
+    }
     // SQINFO("return from getNotationNote with leger line %d pref = %d flats=%d",
     //        midiNote.getLegerLine(pref, bassStaff),
     //        int(pref),

--- a/notes/ScorePitchUtils.h
+++ b/notes/ScorePitchUtils.h
@@ -28,6 +28,7 @@ public:
     };
 
     static NotationNote getNotationNote(const Scale&, const MidiNote&, bool bassStaff);
+    static NotationNote getNotationNoteForce(const Scale&, const MidiNote&, bool bassStaff, bool useSharps);
 
     /**
      * Not needed right now.
@@ -35,10 +36,27 @@ public:
      * @return false if  accidental1 > accidental2
      */
     //  static bool compareAccidentals(Accidental accidental1, Accidental accidental2);
+
+private:
+    static NotationNote getNotationNoteEx(const Scale&, const MidiNote&, bool bassStaff, SharpsFlatsPref pref);
+
 };
+
 
 inline ScorePitchUtils::NotationNote
 ScorePitchUtils::getNotationNote(const Scale& scale, const MidiNote& midiNote, bool bassStaff) {
+    return getNotationNoteEx(scale, midiNote, bassStaff, SharpsFlatsPref::DontCare);
+}
+
+inline ScorePitchUtils::NotationNote
+ScorePitchUtils::getNotationNoteForce(const Scale& scale, const MidiNote& midiNote, bool bassStaff, bool useSharps) {
+    // not correct, but will get tests compiling...
+    return getNotationNote(scale, midiNote, bassStaff);
+}
+
+inline ScorePitchUtils::NotationNote
+ScorePitchUtils::getNotationNoteEx(const Scale& scale, const MidiNote& midiNote, bool bassStaff, SharpsFlatsPref _pref) {
+    assert(_pref == SharpsFlatsPref::DontCare);
     ScaleNote sn = scale.m2s(midiNote);
     scale._validateScaleNote(sn);
     //SQINFO("--in getNotationNote srn octave=%d degree=%d adj=%d (none, sharp, flat)", sn.getOctave(), sn.getDegree(), int(sn.getAdjustment()));

--- a/src/ScoreChord.h
+++ b/src/ScoreChord.h
@@ -50,6 +50,18 @@
  *      cmajor chord in C# Major - accidentals get on key sig. (done)
  *      C and E in C major - doesn't draw the C (fixed)
  *      In C Major one note, I don't see A natural, only sharp?? (user error)
+ * 
+ * How are sharps/flats handled now?
+ * _drawNotes() doesn't care. it divides midi pitches between staves and calls
+ * _drawNotesOnStaff, passing midi pitch and a Scale.
+ * _drawNotesOnStaff makes NotationNote
+ * NotationNote has ScorePitchUtils::Accidental, and int _legerLine;
+ * ScorePitchUtils::getNotationNote uses the pref from the scale. Also it calls Scale::m2s,
+ * and the resulting ScaleNote does have sharp/flat built in.
+ * So, to make it overridable, would need pass a preference into getNotationNote, and of course make it work.
+ * probably means adding a pref to Scale::m2s()
+ * 
+ * experiment 1: make sharps/flats specifiable, and made a test version hard-write to sharps or flats.
  */
 
 // #define _LOG

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -107,7 +107,7 @@ int main(const char**, int) {
         SQINFO("doing special long run");
     }
 
-#if  0
+#if  1
     printf("running only one for temp debug\n");
     assert(SqLog::errorCount == 0);
     testFirst();

--- a/tests/testScale.cpp
+++ b/tests/testScale.cpp
@@ -800,6 +800,37 @@ static void testChromatic2() {
     assertEQ(len, 12);
 }
 
+
+static void testAllPitchSame(Scale& sc, const std::vector<ScaleNotePtr> v) {
+    int refPitch = -1000;
+    ScaleNotePtr ref, other;
+    unsigned otherPitch;
+    for (auto x : v) {
+        if (refPitch < -999) {
+            refPitch = sc.s2m(*x).get();
+            ref = x;
+        } else {
+            const auto pitch = sc.s2m(*x).get();
+            other = x;
+            otherPitch = pitch; 
+            assertEQ(pitch, refPitch);
+        }
+    }
+}
+
+static void testCMajorVariations() {
+    Scale sc;
+    sc.set(MidiNote(MidiNote::C), Scale::Scales::Major);
+
+    auto v = sc.m2sv(MidiNote(MidiNote::C3));
+    assert(!v.empty());
+    assertGT(v.size(), 1);
+
+    testAllPitchSame(sc, v);
+
+    
+}
+
 void testScale() {
     testScaleNumbers();
     testLabels();
@@ -838,8 +869,8 @@ void testScale() {
    
 }
 
-#if 0
+#if 1
 void testFirst() {
-    testm2sDSharp();
+    testCMajorVariations();
 }
 #endif

--- a/tests/testScaleNotes.cpp
+++ b/tests/testScaleNotes.cpp
@@ -222,7 +222,7 @@ static void testCMinor47() {
     assertEQ(sn.getDegree(), 0);
   //  assert(sn.getAdjustment() == ScaleNote::RelativeAdjustment::sharp);
   //  assertEQ(sn.getOctave(), 4);
-    assertEQ(scale._validateScaleNote(sn), true);
+    assertEQ(scale._validateScaleNote(sn, SharpsFlatsPref::DontCare), true);
 }
 
 static void testAll() {
@@ -232,7 +232,7 @@ static void testAll() {
             scale.set(MidiNote(pitch), Scale::Scales(mode));
             for (int testPitch=0; testPitch < 12; ++testPitch) {
                 auto sn = scale.m2s(MidiNote(testPitch));
-                assertEQ(scale._validateScaleNote(sn), true);
+                assertEQ(scale._validateScaleNote(sn, SharpsFlatsPref::DontCare), true);
             }
         }
     }

--- a/tests/testScorePitchUtils.cpp
+++ b/tests/testScorePitchUtils.cpp
@@ -4,7 +4,8 @@
 
 static void test() {
     Scale sc;
-    MidiNote mn;
+    MidiNote mn(MidiNote::C);
+    sc.set(mn, Scale::Scales::Major);
     //     static NotationNote getNotationNote(const Scale&, const MidiNote&, bool bassStaff);
   //  static NotationNote getNotationNoteForce(const Scale&, const MidiNote&, bool bassStaff, bool useSharps);
    ScorePitchUtils::getNotationNote(sc, mn, false);
@@ -20,9 +21,20 @@ static void testCMajor() {
     auto x = ScorePitchUtils::getNotationNote(sc, mnc, false);
     assert(x._accidental == ScorePitchUtils::Accidental::none);
 
-    // This note is also D-. I guess this API uses sharps all the time
+    // Even when we try to "force" C to use sharps or flats it should.
+    x = ScorePitchUtils::getNotationNoteForce(sc, mnc, false, true);
+    assert(x._accidental == ScorePitchUtils::Accidental::none);
+    x = ScorePitchUtils::getNotationNoteForce(sc, mnc, false, false);
+    assert(x._accidental == ScorePitchUtils::Accidental::none);
+
+    // This note is also D-. But C Major defaults to sharps
     x = ScorePitchUtils::getNotationNote(sc, mncSharp, false);
     assert(x._accidental == ScorePitchUtils::Accidental::sharp);
+
+     x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, true);
+    assert(x._accidental == ScorePitchUtils::Accidental::sharp);
+    x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, false);
+    assert(x._accidental == ScorePitchUtils::Accidental::flat);
 }
 
 static void testCMinor() {

--- a/tests/testScorePitchUtils.cpp
+++ b/tests/testScorePitchUtils.cpp
@@ -3,10 +3,12 @@
 #include "asserts.h"
 
 static void test() {
-    // ScorePitchUtils sp;
     Scale sc;
     MidiNote mn;
-   // ScorePitchUtils::getNotationNote(sc, mn);
+    //     static NotationNote getNotationNote(const Scale&, const MidiNote&, bool bassStaff);
+  //  static NotationNote getNotationNoteForce(const Scale&, const MidiNote&, bool bassStaff, bool useSharps);
+   ScorePitchUtils::getNotationNote(sc, mn, false);
+   ScorePitchUtils::getNotationNoteForce(sc, mn, false, true);
 }
 
 static void testCMajor() {
@@ -63,9 +65,9 @@ void testScorePitchUtils() {
     // testCompare();
 }
 
-#if 0
+#if 1
 void testFirst() {
-    //  testScorePitchUtils();
+    testScorePitchUtils();
    // testCMinor();
   // testCompare();
 }

--- a/tests/testScorePitchUtils.cpp
+++ b/tests/testScorePitchUtils.cpp
@@ -6,8 +6,6 @@ static void test() {
     Scale sc;
     MidiNote mn(MidiNote::C);
     sc.set(mn, Scale::Scales::Major);
-    //     static NotationNote getNotationNote(const Scale&, const MidiNote&, bool bassStaff);
-    //  static NotationNote getNotationNoteForce(const Scale&, const MidiNote&, bool bassStaff, bool useSharps);
     ScorePitchUtils::getNotationNote(sc, mn, false);
     ScorePitchUtils::getNotationNoteForce(sc, mn, false, true);
 }
@@ -46,17 +44,20 @@ static void testCMajorCSharp() {
     // This note is also D-. But C Major defaults to sharps
     auto x = ScorePitchUtils::getNotationNote(sc, mncSharp, false);
     assert(x._accidental == ScorePitchUtils::Accidental::sharp);
+    assertEQ(x._legerLine, -2);
+    assert(x._scaleNote.getAdjustment() == ScaleNote::RelativeAdjustment::sharp);
 
     x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, true);
     assert(x._accidental == ScorePitchUtils::Accidental::sharp);
+
     x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, false);
     assert(x._accidental == ScorePitchUtils::Accidental::flat);
+    assertEQ(x._legerLine, -1);
+    assert(x._scaleNote.getAdjustment() == ScaleNote::RelativeAdjustment::flat);
 }
 
 static void testCMinor() {
     Scale sc;
-    // MidiNote mnc(MidiNote::C);
-    // MidiNote mncSharp(MidiNote::C + 1);
     MidiNote mnEFlat(MidiNote::E - 1);
     MidiNote mnE(MidiNote::E);
     sc.set(mnEFlat, Scale::Scales::Minor);
@@ -69,34 +70,15 @@ static void testCMinor() {
     assert(x._accidental == ScorePitchUtils::Accidental::natural);
 }
 
-#if 0
-static void  testCompare() {
-    // First the equal cases
-    bool b = ScorePitchUtils::compareAccidentals(ScorePitchUtils::Accidental::flat, ScorePitchUtils::Accidental::flat);
-    assertEQ(b, true);
-     b = ScorePitchUtils::compareAccidentals(ScorePitchUtils::Accidental::sharp, ScorePitchUtils::Accidental::sharp);
-    assertEQ(b, true);
-     b = ScorePitchUtils::compareAccidentals(ScorePitchUtils::Accidental::natural, ScorePitchUtils::Accidental::natural);
-    assertEQ(b, true);
-     b = ScorePitchUtils::compareAccidentals(ScorePitchUtils::Accidental::none, ScorePitchUtils::Accidental::none);
-    assertEQ(b, true);
-
-    assert(false);
-
-}
-#endif
 void testScorePitchUtils() {
     test();
     testCMajorC();
     testCMajorCSharp();
     testCMinor();
-    // testCompare();
 }
 
-#if 1
+#if 0
 void testFirst() {
     testScorePitchUtils();
-    // testCMinor();
-    // testCompare();
 }
 #endif

--- a/tests/testScorePitchUtils.cpp
+++ b/tests/testScorePitchUtils.cpp
@@ -7,31 +7,47 @@ static void test() {
     MidiNote mn(MidiNote::C);
     sc.set(mn, Scale::Scales::Major);
     //     static NotationNote getNotationNote(const Scale&, const MidiNote&, bool bassStaff);
-  //  static NotationNote getNotationNoteForce(const Scale&, const MidiNote&, bool bassStaff, bool useSharps);
-   ScorePitchUtils::getNotationNote(sc, mn, false);
-   ScorePitchUtils::getNotationNoteForce(sc, mn, false, true);
+    //  static NotationNote getNotationNoteForce(const Scale&, const MidiNote&, bool bassStaff, bool useSharps);
+    ScorePitchUtils::getNotationNote(sc, mn, false);
+    ScorePitchUtils::getNotationNoteForce(sc, mn, false, true);
 }
 
-static void testCMajor() {
+static void testCMajorC() {
     Scale sc;
-    MidiNote mnc(MidiNote::C);
-    MidiNote mncSharp(MidiNote::C + 1);
-    sc.set(mnc, Scale::Scales::Major);
+    MidiNote mnc(MidiNote::C3 + 12);
+    sc.set(MidiNote(MidiNote::C), Scale::Scales::Major);
 
+    // C should default to drawing as C natural
     auto x = ScorePitchUtils::getNotationNote(sc, mnc, false);
     assert(x._accidental == ScorePitchUtils::Accidental::none);
+    assertEQ(x._legerLine, -2);
+    assert(x._scaleNote.getAdjustment() == ScaleNote::RelativeAdjustment::none);
 
-    // Even when we try to "force" C to use sharps or flats it should.
+    //-----------------------------------
+    // Even when we try to "force" C to use sharps or flats it should stay natural
     x = ScorePitchUtils::getNotationNoteForce(sc, mnc, false, true);
     assert(x._accidental == ScorePitchUtils::Accidental::none);
+    assert(x._accidental == ScorePitchUtils::Accidental::none);
+    assertEQ(x._legerLine, -2);
+    assert(x._scaleNote.getAdjustment() == ScaleNote::RelativeAdjustment::none);
+
     x = ScorePitchUtils::getNotationNoteForce(sc, mnc, false, false);
     assert(x._accidental == ScorePitchUtils::Accidental::none);
+    assert(x._accidental == ScorePitchUtils::Accidental::none);
+    assertEQ(x._legerLine, -2);
+    assert(x._scaleNote.getAdjustment() == ScaleNote::RelativeAdjustment::none);
+}
+
+static void testCMajorCSharp() {
+    Scale sc;
+    MidiNote mncSharp(MidiNote::C3 + 12 + 1);
+    sc.set(MidiNote(MidiNote::C), Scale::Scales::Major);
 
     // This note is also D-. But C Major defaults to sharps
-    x = ScorePitchUtils::getNotationNote(sc, mncSharp, false);
+    auto x = ScorePitchUtils::getNotationNote(sc, mncSharp, false);
     assert(x._accidental == ScorePitchUtils::Accidental::sharp);
 
-     x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, true);
+    x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, true);
     assert(x._accidental == ScorePitchUtils::Accidental::sharp);
     x = ScorePitchUtils::getNotationNoteForce(sc, mncSharp, false, false);
     assert(x._accidental == ScorePitchUtils::Accidental::flat);
@@ -42,16 +58,15 @@ static void testCMinor() {
     // MidiNote mnc(MidiNote::C);
     // MidiNote mncSharp(MidiNote::C + 1);
     MidiNote mnEFlat(MidiNote::E - 1);
-    MidiNote mnE(MidiNote::E );
+    MidiNote mnE(MidiNote::E);
     sc.set(mnEFlat, Scale::Scales::Minor);
 
     // In C minor, E flat notated needs no accidental
-  auto x = ScorePitchUtils::getNotationNote(sc, mnEFlat, false);
-  assert(x._accidental == ScorePitchUtils::Accidental::none);
+    auto x = ScorePitchUtils::getNotationNote(sc, mnEFlat, false);
+    assert(x._accidental == ScorePitchUtils::Accidental::none);
 
-  x = ScorePitchUtils::getNotationNote(sc, mnE, false);
-  assert(x._accidental == ScorePitchUtils::Accidental::natural);
-    
+    x = ScorePitchUtils::getNotationNote(sc, mnE, false);
+    assert(x._accidental == ScorePitchUtils::Accidental::natural);
 }
 
 #if 0
@@ -72,7 +87,8 @@ static void  testCompare() {
 #endif
 void testScorePitchUtils() {
     test();
-    testCMajor();
+    testCMajorC();
+    testCMajorCSharp();
     testCMinor();
     // testCompare();
 }
@@ -80,7 +96,7 @@ void testScorePitchUtils() {
 #if 1
 void testFirst() {
     testScorePitchUtils();
-   // testCMinor();
-  // testCompare();
+    // testCMinor();
+    // testCompare();
 }
 #endif

--- a/util/quant/Scale.h
+++ b/util/quant/Scale.h
@@ -8,6 +8,7 @@
 #include "ScaleNote.h"
 #include "SharpsFlatsPref.h"
 
+
 class Scale {
 public:
     enum class Scales {
@@ -98,6 +99,9 @@ public:
      * @return ScaleNote
      */
     ScaleNote m2s(const MidiNote&) const;
+    ScaleNote m2s(const MidiNote&, SharpsFlatsPref pref) const; 
+    std::vector<ScaleNotePtr> m2sv(const MidiNote&) const;
+
 
     MidiNote s2m(const ScaleNote&) const;
 
@@ -144,9 +148,10 @@ public:
      */
     const int* _getNormalizedScalePitches() const;
 
-    bool _validateScaleNote(const ScaleNote&) const;
+    bool _validateScaleNote(const ScaleNote&, SharpsFlatsPref pref) const;
 private:
-    ScaleNote _makeScaleNote(int offset) const;
+    // pref - don't care means get from scale.
+    ScaleNote _makeScaleNote(int offset, SharpsFlatsPref pref) const;
 
     MidiNote _baseNote;
     Scales _scale;

--- a/util/quant/ScaleNote.h
+++ b/util/quant/ScaleNote.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <memory>
+
 /**
  * Can represent any pitch, but is in context for a scale
  * 
  */
 class ScaleNote {
 public:
+    friend class Scale;
     /**
      * This used to be called Accidental, but really it's and adjustment from the pitch in the
      * scale.
@@ -53,3 +56,5 @@ private:
     int _octave = 0;
     RelativeAdjustment _relativeAdjustment = RelativeAdjustment::none;
 };
+
+using ScaleNotePtr = std::shared_ptr<ScaleNote>;


### PR DESCRIPTION
DONT MERGE
This branch attempted to improve enharmonic spelling by making ScaleNote overridable. seems like the wrong way to go.